### PR TITLE
Altered ProtonVPN API Updater to use auth tokens

### DIFF
--- a/internal/provider/protonvpn/updater/api.go
+++ b/internal/provider/protonvpn/updater/api.go
@@ -33,15 +33,77 @@ type physicalServer struct {
 	X25519PublicKey string     `json:"X25519PublicKey"`
 }
 
+// Session Structure for the sessions api endpoint
+
+type protonSession struct {
+	Code         int64         `json:"Code"`
+	AccessToken  string        `json:"AccessToken"`
+	RefreshToken string        `json:"RefreshToken"`
+	TokenType    string        `json:"TokenType"`
+	Scopes       []interface{} `json:"Scopes"` // This is likely to be []string, however cannot confirm
+	UID          string        `json:"UID"`
+	LocalID      int64         `json:"LocalID"`
+}
+
 func fetchAPI(ctx context.Context, client *http.Client) (
 	data apiData, err error,
 ) {
-	const url = "https://api.protonmail.ch/vpn/logicals"
+	var pmSession protonSession
+
+	const TokenType = "Bearer"
+	const ProtonAppVer = "web-account@5.0.235.1" // Setting this here incase version needs updating
+	const sessionsURL = "https://account.proton.me/api/auth/v4/sessions"
+
+	// Old Logicals API endpoint: https://api.protonmail.ch/vpn/logicals
+	// New Logicals API endpoint: https://account.proton.me/api/vpn/logicals
+
+	const url = "https://account.proton.me/api/vpn/logicals"
+
+	sessionRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, sessionsURL, nil)
+	if err != nil {
+		return data, err
+	}
+
+	// Setup API Request Headers, using app information as the web-account app
+	// US locale and force an unauthed session, only the x-pm-appversion header
+	// is required the other two headers are optional
+
+	sessionRequest.Header.Set("x-pm-appversion", ProtonAppVer)
+	sessionRequest.Header.Set("x-pm-locale", "en_US")
+	sessionRequest.Header.Set("x-enforce-unauthsession", "true")
+
+	sessionResponse, err := client.Do(sessionRequest)
+	if err != nil {
+		return data, err
+	}
+	defer sessionResponse.Body.Close()
+
+	if sessionResponse.StatusCode != http.StatusOK {
+		return data, fmt.Errorf("%w: %d %s", ErrHTTPStatusCodeNotOK,
+			sessionResponse.StatusCode, sessionResponse.Status)
+	}
+
+	sessionDecoder := json.NewDecoder(sessionResponse.Body)
+	if err := sessionDecoder.Decode(&pmSession); err != nil {
+		return data, fmt.Errorf("decoding session response body: %w", err)
+	}
+
+	if err := sessionResponse.Body.Close(); err != nil {
+		return data, err
+	}
 
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return data, err
 	}
+
+	// Setup the auth token from the newly obtained session, the logicals API end
+	// point requires in addition to the auth token two custom header entries
+	// one specifying the app that made the request and the proton uid attached
+	// to the session. If either are missing a HTTP 401 is returned
+	request.Header.Set("Authorization", TokenType+" "+pmSession.AccessToken)
+	request.Header.Set("x-pm-uid", pmSession.UID)
+	request.Header.Set("x-pm-appversion", ProtonAppVer)
 
 	response, err := client.Do(request)
 	if err != nil {


### PR DESCRIPTION
Updated ProtonVPN Updater fetchAPI code to implement the using an Bearer Authorization Token to address recent Logicals API endpoint changes that now force connections to use a valid session and corresponding auth token.

Code makes request to Proton's Sessions API generating a new unauthenticated session, using the UID and AccessToken provided by the API to add Authorization header and Protons required custom headers to the Logicals API endpoint request. To ensure that the token scope works the Logicals API endpoint was also changed to the one provided on the account.proton.me domain endpoint as this is where the sessions API is based.